### PR TITLE
Remove spaces from phone number

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,12 @@
-FROM mcr.microsoft.com/devcontainers/javascript-node:1-18-bullseye
+FROM node:18
+
+# Install basic development tools
+RUN apt update && apt install -y less man-db sudo
+
+# Ensure default `node` user has access to `sudo`
+ARG USERNAME=node
+RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Set `DEVCONTAINER` environment variable to help with orientation
+ENV DEVCONTAINER=true

--- a/src/functions/WebToLeadFormParserService.mjs
+++ b/src/functions/WebToLeadFormParserService.mjs
@@ -29,6 +29,11 @@ app.http("WebToLeadFormParserService", {
       // Add the web source to the output data
       outputData.webSource = "USEDMOBILITYSCOOTERSHOP.CO.UK";
 
+      // remove any spaces from the phone number
+      if (outputData.phone) {
+        outputData.phone = outputData.phone.replace(/\s/g, "");
+      }
+
       context.log("Web-to-Lead form submission successfully parsed");
 
       return {

--- a/test/WebToLeadFormParserService/index.test.mjs
+++ b/test/WebToLeadFormParserService/index.test.mjs
@@ -41,4 +41,17 @@ describe("WebToLeadFormParserService", () => {
     const actualParsedFormPayload = await getParsedFormPayload(undefined);
     assert.deepStrictEqual(actualParsedFormPayload, expectedParsedFormPayload);
   });
+
+  it("should correctly set the value of websource", async () => {
+    const actualParsedFormPayload = await getParsedFormPayload(formPayload);
+    assert.strictEqual(
+      actualParsedFormPayload.webSource,
+      "USEDMOBILITYSCOOTERSHOP.CO.UK",
+    );
+  });
+
+  it("should remove spaces from the phone number", async () => {
+    const actualParsedFormPayload = await getParsedFormPayload(formPayload);
+    assert.strictEqual(actualParsedFormPayload.phone, "07718991900");
+  });
 });

--- a/test/WebToLeadFormParserService/web-to-lead-form-request.json
+++ b/test/WebToLeadFormParserService/web-to-lead-form-request.json
@@ -117,11 +117,11 @@
   },
   {
     "key": "fields[phone][value]",
-    "value": "07718991900"
+    "value": "07718 991900"
   },
   {
     "key": "fields[phone][raw_value]",
-    "value": "07718991900"
+    "value": "07718 991900"
   },
   {
     "key": "fields[phone][required]",


### PR DESCRIPTION
Updated the website Sell your scooter form phone number field from type telephone to text.  This was to make the phone number field formatting more flexible due to issues users were experiencing with submitting forms.

Due to the form field being a text field, users can now submit the phone number with spaces included.  To ensure consistency the function has been updated to remove any spaces from the phone number.